### PR TITLE
Sort hash for ruby<1.9.2 support

### DIFF
--- a/lib/puppet/parser/functions/command_args.rb
+++ b/lib/puppet/parser/functions/command_args.rb
@@ -57,7 +57,7 @@ command_args($arguments, '-')
 
     parameters = ""
 
-    hash.map do |k,v|
+    hash.sort.map do |k,v|
       if v.is_a?(Array)
         v.each do |item|
           if item.is_a?(String) or item.is_a?(Numeric)


### PR DESCRIPTION
We are running ruby 1.8 on our boxes. Because ruby versions older than 1.9.2 don't support ordered hashes our puppet runs are no longer idempotent when using this module.

This PR loops through the hash in sorted order so that the output string is consistent.
